### PR TITLE
Update sentence_transformers to version 3.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pydata-sphinx-theme==0.15.4",
     "pytest==8.3.2",
     "scikit_learn==1.5.1",
-    "sentence_transformers==3.0.1",
+    "sentence_transformers==3.1.1",
     "sphinx==7.4.7",
     "sphinx_book_theme==1.1.3",
     "torch==2.3.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ plotly==5.23.0
 pydata-sphinx-theme==0.15.4
 pytest==8.3.2
 scikit_learn==1.5.1
-sentence_transformers==3.0.1
+sentence_transformers==3.1.1
 sphinx==7.4.7
 sphinx_book_theme==1.1.3
 torch==2.3.1


### PR DESCRIPTION
Hello ! 

I was using ragoon to try the new lemone release, and face a warning on my environement ; 

```
torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
You try to use a model that was created with version 3.1.1, however, your version is 3.0.1. This might cause unexpected behavior or errors. In that case, try to update to the latest version.
```

Then i try to pip install --upgrade sentence_transformers to 3.1.1, but it say ragoon was using and need 3.0.1.

**I will require strong vigilance from Reviewer as i'm not aware of all the consequences that have such a version bump from sentence_transformers** 

Thanks you so much for you're incredible work it give so much hope for french / open source community 🦝